### PR TITLE
README.md: Change grml.github.com to grml.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 Contributing
 ============
 
-Want to contribute to [Grml](https://grml.org/)? Great! Please head over to [grml.github.com](https//grml.github.com/)
+Want to contribute to [Grml](https://grml.org/)? Great! Please head over to [grml.github.io](https//grml.github.io/)
 
 About
 -----
 
-This is the Git repository which drives [grml.github.com](https://grml.github.com/)
+This is the Git repository which drives [grml.github.io](https://grml.github.io/)
 
 Author
 ------


### PR DESCRIPTION
grml.github.com does not exist.

Changing the URLs to grml.github.io

See: grml/grml.github.com#5